### PR TITLE
Convert overlap fixing to iterative dataframe-based method

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,10 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.10
+python_requires = >=3.8
 install_requires = 
-    numpy >= 1.24.2
-    scipy >= 1.10.1
+    numpy >= 1.19.0
+    scipy >= 1.5.2
     polars >= 0.16.16
 
 [options.extras_require]

--- a/tests/test_overlap_fixer.py
+++ b/tests/test_overlap_fixer.py
@@ -1,83 +1,80 @@
-from transfer_linkage import overlap_fixer
-
+from transfer_linkage import overlap_fixer as ovlfxr
+import polars as pl
+from datetime import datetime
 
 def test_simple_overlap():
-    data = [
-        ('0001', 1, 4,),
-        ('0002', 2, 6,),
-    ]
+    df = pl.DataFrame(
+        {
+            'sID': [1, 1, 1, 1],
+            'fID': ['A', 'B', 'C', 'D'],
+            'Adate': [
+                datetime(year=2000, month=1, day=1),
+                datetime(year=2000, month=2, day=1),
+                datetime(year=2000, month=3, day=1),
+                datetime(year=2000, month=4, day=1),
+            ],
+            'Ddate': [
+                datetime(year=2000, month=1, day=15),
+                datetime(year=2000, month=3, day=10),
+                datetime(year=2000, month=3, day=28),
+                datetime(year=2000, month=4, day=15),
+            ]
+        }
+    )
 
-    fixed_intervals = overlap_fixer.clean_overlaps(data)
+    ff = ovlfxr.fix_overlaps(df, 1)
 
-    assert fixed_intervals == [
-        ('0001', 1, 2),
-        ('0002', 2, 6),
-    ]
+    assert ovlfxr.num_overlaps(ff) == 0
 
-def test_returning_overlap():
-    data = [
-        ('001', 1, 6),
-        ('002', 2, 4),
-    ]
+def test_consuming_overlap():
+    df = pl.DataFrame(
+        {
+            'sID': [1, 1, 1, 1],
+            'fID': ['A', 'B', 'C', 'D'],
+            'Adate': [
+                datetime(year=2000, month=1, day=1),
+                datetime(year=2000, month=2, day=1),
+                datetime(year=2000, month=3, day=1),
+                datetime(year=2000, month=4, day=1),
+            ],
+            'Ddate': [
+                datetime(year=2000, month=1, day=15),
+                datetime(year=2000, month=3, day=28),
+                datetime(year=2000, month=3, day=10),
+                datetime(year=2000, month=4, day=15),
+            ]
+        }
+    )
 
-    fixed_intervals = overlap_fixer.clean_overlaps(data)
+    ff = ovlfxr.fix_overlaps(df, 1)
 
-    assert fixed_intervals == [
-        ('001', 1, 2),
-        ('002', 2, 4),
-        ('001', 4, 6),
-    ]
+    assert ovlfxr.num_overlaps(ff) == 0
 
-def test_multiple_admissions():
-    data = [
-        ('001', 1, 6),
-        ('001', 7, 9),
-    ]
+def test_dead_heat_overlap():
+    df = pl.DataFrame(
+        {
+            'sID': [1, 1, 1, 1],
+            'fID': ['A', 'B', 'C', 'D'],
+            'Adate': [
+                datetime(year=2000, month=1, day=1),
+                datetime(year=2000, month=2, day=1),
+                datetime(year=2000, month=2, day=1),
+                datetime(year=2000, month=4, day=1),
+            ],
+            'Ddate': [
+                datetime(year=2000, month=1, day=15),
+                datetime(year=2000, month=3, day=10),
+                datetime(year=2000, month=3, day=28),
+                datetime(year=2000, month=4, day=15),
+            ]
+        }
+    )
 
-    fixed_intervals = overlap_fixer.clean_overlaps(data)
+    ff = ovlfxr.fix_overlaps(df, 1)
 
-    assert fixed_intervals == data
+    assert ovlfxr.num_overlaps(ff) == 0
 
-def test_nesting_overlaps():
-    data = [
-        ('a', 1, 4),
-        ('b', 2, 6),
-        ('c', 3, 5),
-        ('b', 7, 8),
-    ]
-
-    fixed_intervals = overlap_fixer.clean_overlaps(data)
-
-    assert fixed_intervals == [
-        ('a', 1, 2),
-        ('b', 2, 3),
-        ('c', 3, 5),
-        ('b', 5, 6),
-        ('b', 7, 8),
-    ]
-
-def test_continuity_case():
-    data = [
-        ('a', 1, 3),
-        ('a', 2, 4),
-    ]
-
-    fixed_intervals = overlap_fixer.clean_overlaps(data)
-
-    assert fixed_intervals == [
-        ('a', 1, 2),
-        ('a', 2, 4),
-    ]
-
-def test_concurrent_overlap():
-    data = [
-        ('a', 1, 4),
-        ('b', 2, 4),
-    ]
-
-    fixed_intervals = overlap_fixer.clean_overlaps(data)
-
-    assert fixed_intervals == [
-        ('a', 1, 2),
-        ('b', 2, 4),
-    ]
+if __name__ == "__main__":
+    test_simple_overlap()
+    test_consuming_overlap()
+    test_dead_heat_overlap()

--- a/transfer_linkage/cleaner.py
+++ b/transfer_linkage/cleaner.py
@@ -89,8 +89,8 @@ def coerce_data_types(database:pl.DataFrame, convert_dates=False, date_format=r'
         if verbose:
             print("Converting dates...")
         date_expressions = [
-            pl.col('Adate').str.strptime(pl.Datetime, fmt=date_format),
-            pl.col('Ddate').str.strptime(pl.Datetime, fmt=date_format),
+            pl.col('Adate').str.strptime(pl.Datetime, format=date_format),
+            pl.col('Ddate').str.strptime(pl.Datetime, format=date_format),
         ]
     else:
         # do nothing

--- a/transfer_linkage/cleaner.py
+++ b/transfer_linkage/cleaner.py
@@ -26,6 +26,8 @@ def clean_database(
     facility_id="fID",
     admission_date='Adate',
     discharge_date='Ddate',
+    subject_dtype=pl.Utf8,
+    facility_dtype=pl.Utf8,
     retain_auxiliary_data=True,
     n_iters=100,
     verbose=True
@@ -33,7 +35,7 @@ def clean_database(
 
     report = standardise_column_names(database, subject_id, facility_id, admission_date, discharge_date, verbose)
 
-    report = coerce_data_types(report, convert_dates, date_format, verbose)
+    report = coerce_data_types(report, convert_dates, date_format, subject_dtype, facility_dtype, verbose)
 
     # Trim auxiliary data
     if not retain_auxiliary_data:
@@ -81,7 +83,8 @@ def standardise_column_names(df:pl.DataFrame, subject_id="sID", facility_id="fID
         discharge_date: 'Ddate',
     })
 
-def coerce_data_types(database:pl.DataFrame, convert_dates=False, date_format=r'%Y-%m-%d', verbose=True):
+def coerce_data_types(database:pl.DataFrame, convert_dates=False, date_format=r'%Y-%m-%d', 
+                      subject_dtype=pl.Utf8, facility_dtype=pl.Utf8, verbose=True):
         # Check data format, column names, variable format, parse dates
     if verbose:
         print("Coercing types...")
@@ -100,8 +103,8 @@ def coerce_data_types(database:pl.DataFrame, convert_dates=False, date_format=r'
         ]
     # Coerce types
     database = database.with_columns([
-        pl.col('sID').cast(pl.Utf8),
-        pl.col('fID').cast(pl.Utf8),
+        pl.col('sID').cast(subject_dtype),
+        pl.col('fID').cast(facility_dtype),
         *date_expressions,
     ])
     if verbose:


### PR DESCRIPTION
Applying the naive explicit overlap fixing method on the ECHIDNA data, which is ~26 million rows, causes two problems:
1. blowup of memory usage, since the number of events is roughly 2 x sum [ number of events per person ^2 ]
2. very slow runtime

Problem 1 can be resolved partially by using `.groupby('sID').apply(...)` instead of `.partition_by('sID')`. This prevents the entire set of partitions to be eagerly generated into memory.
Problem 2 is only solved by using the pola-rs library internals (dataframe-based methods) instead of python iteration.

We implement this method using a few tricks and there are a few sharp corners:
1. We detect and remove non-overlapping people before performing the more expensive fixing operations. These are cached away at each iteration (so that each iteration has its own dataframe of non-overlapping people that is distinct from the others), and then concatenated at the end.
2. We construct additional columns for enveloping overlaps, which are then separately parsed out and then rejoined with the other columns. This gets us the extra rows we need to make enveloping intervals consistent
3. Anomalies can occur if two sequential presences start at the same time, and then there is a third event that starts before both of the others finish. We fix anomalies by performing a small post check that shrinks the longer duration location to zero-time, and moves the other location's Ddate back. This **differs** from Hospinet, which will shrink the shorter duration location to zero-time.
4. We use a LazyFrame as much as possible, in order to allow for automatic engine optimisations on `.collect()`ing to a realised DataFrame.
